### PR TITLE
Adding Work Packages to Funding awards 

### DIFF
--- a/app/Http/Livewire/Input/Funders.php
+++ b/app/Http/Livewire/Input/Funders.php
@@ -7,7 +7,7 @@ use App\Models\Dataset;
 use App\Models\FundingAward;
 class Funders extends Component
 {
-    public $funder;
+    public $funderID = 6;
     public $comment;
     public $dsfunderid;
     public $awards;
@@ -20,8 +20,23 @@ class Funders extends Component
         $this->dsfunderid = Dataset::where('id', $this->dataset_id)->first()->funders()->pluck('funding_awards.id')->toArray();
         $this->awards = FundingAward::all()->whereNotIn('id', $this->dsfunderid)->sortBy('title', SORT_NATURAL|SORT_FLAG_CASE);
         //$this->awards = FundingAward::all()->sortBy('title', SORT_NATURAL|SORT_FLAG_CASE);
+        // I am getting the comment from the database: this will be the list of work packages. The curator will then delete those that do not apply
+        $this ->  getComment();
+    }
+    public function getComment()
+    {
+        if ($this->funderID != '') {
+            $this->comment = FundingAward::where('id', $this->funderID)->pluck('WorkPackages');
+        } else {
+            $this->comment = '';
+        }
+    }
+    public function updatedFunderID() {
+        $this -> getComment();
 
     }
+
+
 
     public function refresh() {
         $this->dataset = Dataset::find($this->dataset_id);
@@ -32,7 +47,7 @@ class Funders extends Component
 
     public function addFunder() {
 
-        $this->dataset->funders()->attach($this->funder, ['comment'=>$this->comment]);
+        $this->dataset->funders()->attach($this->funderID, ['comment'=>$this->comment]);
         $this->refresh();
     }
 

--- a/app/Http/Livewire/Input/Funders.php
+++ b/app/Http/Livewire/Input/Funders.php
@@ -7,7 +7,7 @@ use App\Models\Dataset;
 use App\Models\FundingAward;
 class Funders extends Component
 {
-    public $funderID = 6;
+    public $funderID = 0;
     public $comment;
     public $dsfunderid;
     public $awards;
@@ -25,10 +25,10 @@ class Funders extends Component
     }
     public function getComment()
     {
-        if ($this->funderID != '') {
+        if ($this->funderID != 0) {
             $this->comment = FundingAward::where('id', $this->funderID)->pluck('WorkPackages');
         } else {
-            $this->comment = '';
+            $this->comment = 'Delete what is not needed';
         }
     }
     public function updatedFunderID() {
@@ -39,10 +39,12 @@ class Funders extends Component
 
 
     public function refresh() {
+        $this->funderID = 0;
         $this->dataset = Dataset::find($this->dataset_id);
         $this->dsfunderid = Dataset::where('id', $this->dataset_id)->first()->funders()->pluck('funding_awards.id')->toArray();
         $this->awards = FundingAward::all()->whereNotIn('id', $this->dsfunderid)->sortBy('title', SORT_NATURAL|SORT_FLAG_CASE);
         //$this->awards = FundingAward::all()->sortBy('title', SORT_NATURAL|SORT_FLAG_CASE);
+        $this ->  getComment();
     }
 
     public function addFunder() {

--- a/app/Http/Livewire/Input/Funders.php
+++ b/app/Http/Livewire/Input/Funders.php
@@ -8,6 +8,7 @@ use App\Models\FundingAward;
 class Funders extends Component
 {
     public $funder;
+    public $comment;
     public $dsfunderid;
     public $awards;
     public $filteredfunders;
@@ -30,7 +31,8 @@ class Funders extends Component
     }
 
     public function addFunder() {
-        $this->dataset->funders()->attach($this->funder);
+
+        $this->dataset->funders()->attach($this->funder, ['comment'=>$this->comment]);
         $this->refresh();
     }
 

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -51,7 +51,7 @@ class Dataset extends Model
     }
     public function funders()
     {
-        return $this->belongsToMany(FundingAward::class, 'document_funders', 'metadata_document_id', 'funding_award_id');
+        return $this->belongsToMany(FundingAward::class, 'document_funders', 'metadata_document_id', 'funding_award_id')->withPivot('comment');
     }
     public function authors()
     {

--- a/resources/views/datasets/show.blade.php
+++ b/resources/views/datasets/show.blade.php
@@ -240,7 +240,7 @@ old_md_id --}}
                                 @foreach ($dataset->funders as $funder)
                                     <li>{{ $funder->reference_number }} : <a class="text-blue-600 visited:text-pink-900 hover:text-blue-800 hover:underline"
                                             href="{{ $funder->uri }}">{{ $funder->title }}</a>
-                                        ({{ $funder->organisation->abbreviation }})
+                                        ({{ $funder->organisation->abbreviation }}) - {{ $funder->pivot->comment }}
                                     </li>
                                 @endforeach
                             </ul>

--- a/resources/views/livewire/input/contributors.blade.php
+++ b/resources/views/livewire/input/contributors.blade.php
@@ -49,7 +49,7 @@
                 {{ $loop->last ? 'border-b ' : '' }}
                 ">
                     <td class="w-1/3 text-left py-3 px-4">
-                        <label class="ml-7">{{ $filteredPerson->family_name }}, {{ $filteredPerson->given_name }}</label>
+                        <label class="ml-7">{{ $contributor->family_name }}, {{ $contributor->given_name }}</label>
                     </td>
                     <td class="w-1/3 text-left py-3 px-4">
                         <label class="ml-7">{{ $contributor->pivot->person_role_type->type_value  }}</label>

--- a/resources/views/livewire/input/funders.blade.php
+++ b/resources/views/livewire/input/funders.blade.php
@@ -10,7 +10,7 @@
         </thead>
         <tbody>
             <tr class="bg-slate-300">
-                <td class="w-5/6 text-left py-3 px-4">
+                <td class="w-3/6 text-left py-3 px-4">
                     <select class="form-select block w-full mt-1 rounded-md"
                         wire:model='funder'>
                         <option value="">Choose a Funding Award</option>
@@ -21,7 +21,13 @@
                             </option>
                         @endforeach
                     </select>
+
                 </td>
+                <td class="w-2/6 text-left py-3 px-4">
+                    <input class="form-input block w-full mt-1 rounded-md "
+                        wire:model='comment'>
+                </td>
+
                 <td class="w-1/6 py-3 px-4 text-right">
                     <button
                         class="disable:cursor-not-allowed rounded bg-indigo-500 py-2 px-4 text-white hover:bg-indigo-500 disabled:bg-opacity-10"
@@ -38,7 +44,12 @@
                 <td class="w-5/6 text-left py-1 px-4">
                     <label class="ml-7">
                                 {{ $funder->reference_number }} - {{ $funder->title }}
-                                ({{ $funder->organisation->abbreviation }})</label>
+                                ({{ $funder->organisation->abbreviation }})
+                            @if ($funder->pivot->comment )
+                               - {{ $funder->pivot->comment }}
+                            @else
+                            @endif
+                    </label>
 
                 </td>
                 <td class="w-1/6 py-1 px-4 text-right">

--- a/resources/views/livewire/input/funders.blade.php
+++ b/resources/views/livewire/input/funders.blade.php
@@ -35,7 +35,7 @@
                             </span>
                     <input class="form-input block w-full mt-1 rounded-md "
                     id = "comment"
-                        wire:model='comment'>
+                    wire:model='comment'>
                         </label>
                 </td>
                 <td class="w-1/6 py-3 px-4 text-right">

--- a/resources/views/livewire/input/funders.blade.php
+++ b/resources/views/livewire/input/funders.blade.php
@@ -10,9 +10,12 @@
         </thead>
         <tbody>
             <tr class="bg-slate-300">
-                <td class="w-3/6 text-left py-3 px-4">
-                    <select class="form-select block w-full mt-1 rounded-md"
-                        wire:model='funder'>
+                <td class="w-5/6 text-left py-3 px-4">
+                    <label class="block">
+                        <span class="p-2 text-sm text-gray-400">Choose the ISP or main award
+                        </span>
+                    <select class="form-select block w-full mt-1 rounded-md" id="funderID"
+                        wire:model='funderID'>
                         <option value="">Choose a Funding Award</option>
                         @foreach ($awards as $award)
                             <option value="{{ $award->id }}">
@@ -21,18 +24,26 @@
                             </option>
                         @endforeach
                     </select>
+                    </label>
 
                 </td>
-                <td class="w-2/6 text-left py-3 px-4">
+                <td></td></tr>
+            <tr class="bg-slate-300">
+                    <td class="w-5/6 text-left py-3 px-4">
+                        <label class="block">
+                            <span class="p-2 text-sm text-gray-400">List of Work Packages: delete what's not needed
+                            </span>
                     <input class="form-input block w-full mt-1 rounded-md "
+                    id = "comment"
                         wire:model='comment'>
+                        </label>
                 </td>
-
                 <td class="w-1/6 py-3 px-4 text-right">
                     <button
                         class="disable:cursor-not-allowed rounded bg-indigo-500 py-2 px-4 text-white hover:bg-indigo-500 disabled:bg-opacity-10"
                         wire:click.prevent="addFunder">Add</button>
-                </td>
+                <td></td></tr>
+
             </tr>
 
 


### PR DESCRIPTION
We have added code to support work packages; There is a column in funding awards which suggests work packages. They are then loaded in a comment field. The curator can edit that field to only list the relelvant work packages. So I am not using a many to many, that saves complexity because the Datacite looks at grants, not WPs. but we also want that comment